### PR TITLE
include license and readme in pypi tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 recursive-include mkdocs_alabaster *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+include README.md
+include LICENSE


### PR DESCRIPTION
Hi I am the maintainer of mkdocs in Fedora/Epel I am working in packaging your theme I wan to include the license text and readme in the tarball
