### PR TITLE
Add customizable sidebars and navigation sidebar.

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -105,6 +105,23 @@ extra:
     - search
 ```
 
+### Navigation sidebar
+
+The table of contents sidebar includes only the current page's headings. If you
+want to have the global navigation in the menu, use an alternative sidebar
+called `navigation`:
+
+```yaml
+extra:
+  sidebars:
+    - about
+    - navigation
+    - related
+    - search
+```
+
+This is a port of the original Alabaster theme's sidebar of the same name.
+
 ### Example
 
 ```yaml

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -57,9 +57,53 @@ extra:
     Fork me on GitHub: https://github.com/iamale/rock-cli
 ```
 
-### `extra.show_powered_by`
+#### `extra.show_powered_by`
 
 Show “Powered by” message, mentioning MkDocs and this theme. Default: true.
+
+#### `extra.sidebars`
+
+Specify sidebars shown in the left menu. By default, the following ones are
+shown, top to bottom:
+
+  - `about`: logo and title (`sidebars/about.html`)
+  - `toc`: current page table of contents (`sidebars/toc.html`)
+  - `related`: links to the previous and next pages (`sidebars/related.html`)
+  - `search`: quick search (`sidebars/search.html`)
+
+To add your own sidebar, put its template in `$THEME_DIR/sidebars` and add its
+name to `extra.sidebars`:
+
+```yaml
+extra:
+  sidebars:
+    - about
+    - toc
+    - my-awesome-sidebar # corresponds to `$THEME_DIR/sidebars/my-awesome-sidebar.html`
+    - related
+    - search
+```
+
+#### `extra.homepage_sidebars`
+
+List of sidebar names shown in the left menu *on the homepage only*.
+By default, the following sidebars are shown, top to bottom:
+
+  - `about`: logo and title (`sidebars/about.html`)
+  - `search`: quick search (`sidebars/search.html`)
+
+As you see, homepage is a little special as it doesn't have `toc` and `related`
+sidebars by default. The option `extra.homepage_sidebars` lets you easily
+override this behavior:
+
+```yaml
+extra:
+  homepage_sidebars:
+    - about
+    - toc
+    - related
+    - search
+```
 
 ### Example
 

--- a/mkdocs_alabaster/config.html
+++ b/mkdocs_alabaster/config.html
@@ -1,10 +1,12 @@
 {% set c = config %}
 {% set e = config.extra %}
 {% set theme = {
-  "logo": e.logo                       | default(false),
-  "logo_title": e.logo_title           | default(c.site_name),
-  "logo_name": e.logo_name             | default(false),
-  "include_toc": e.include_toc         | default(true),
-  "extra_nav_links": e.extra_nav_links | default({}),
-  "show_powered_by": e.show_powered_by | default(true),
+  "logo": e.logo                           | default(false),
+  "logo_title": e.logo_title               | default(c.site_name),
+  "logo_name": e.logo_name                 | default(false),
+  "include_toc": e.include_toc             | default(true),
+  "extra_nav_links": e.extra_nav_links     | default({}),
+  "show_powered_by": e.show_powered_by     | default(true),
+  "sidebars": e.sidebars                   | default(["about", "toc", "related", "search"]),
+  "homepage_sidebars": e.homepage_sidebars | default(["about", "search"]),
 }%}

--- a/mkdocs_alabaster/main.html
+++ b/mkdocs_alabaster/main.html
@@ -53,12 +53,15 @@
     </div>
     <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
       <div class="sphinxsidebarwrapper">
-        {% include "sidebars/about.html" %}
-        {% if nav.homepage.url != "." %}
-          {% include "sidebars/toc.html" %}
-          {% include "sidebars/related.html" %}
+        {% if nav.homepage.url == "." %}
+          {% for sidebar in theme.homepage_sidebars %}
+            {% include "sidebars/%s.html" % sidebar %}
+          {% endfor %}
+        {% else %}
+          {% for sidebar in theme.sidebars %}
+            {% include "sidebars/%s.html" % sidebar %}
+          {% endfor %}
         {% endif %}
-        {% include "sidebars/search.html" %}
       </div>
     </div>
     <div class="clearer"></div>

--- a/mkdocs_alabaster/sidebars/navigation.html
+++ b/mkdocs_alabaster/sidebars/navigation.html
@@ -1,0 +1,50 @@
+{% macro _toc_tree_inner(toc) -%}
+  <ul>
+    {% for toc_item in toc %}
+      <li><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+      {{ _toc_tree_inner(toc_item.children) }}
+    {% endfor %}
+  </ul>
+{%- endmacro %}
+
+{% macro toc_tree(toc) -%}
+  {# This ignores H1s #}
+  {% for toc_item in toc %}
+    {{ _toc_tree_inner(toc_item.children) }}
+  {% endfor %}
+{%- endmacro %}
+
+{% macro nav_tree(nav) -%}
+  <ul>
+  {% for nav_item in nav %}
+    {% if not nav_item.children %}
+      <li>
+        <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+      </li>
+      {% if nav_item == page %}
+        {{ toc_tree(page.toc) }}
+      {% endif %}
+    {% else %}
+      <li>
+        {{ nav_item.title }}
+        {{ nav_tree(nav_item.children) }}
+      </li>
+    {% endif %}
+  {% endfor %}
+  </ul>
+{%- endmacro %}
+
+<h3>Navigation</h3>
+
+<nav>
+  {{ nav_tree(nav) }}
+
+  {% if theme.extra_nav_links %}
+    <hr>
+    <ul>
+      {% for text, uri in theme.extra_nav_links.items() %}
+        <li class="toctree-l1"><a href="{{ uri }}">{{ text }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+</nav>


### PR DESCRIPTION
Added two config options: `extra.sidebars` and `extra.homepage_sidebars`. Both are lists of sidebar names where a name is simply the template file name without the ".html" suffix.

To preserve backward compatibility, the default values for the new options are set to match the existing appearance. That is, home page does not have ToC or "related pages" sidebars.