### PR TITLE
Make homepage navigation optional

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -87,6 +87,10 @@ extra:
     - search
 ```
 
+#### `extra.homepage_nav`
+
+Show navigation tree on homepage. Default: true.
+
 #### `extra.homepage_sidebars`
 
 List of sidebar names shown in the left menu *on the homepage only*.

--- a/mkdocs_alabaster/config.html
+++ b/mkdocs_alabaster/config.html
@@ -8,5 +8,6 @@
   "extra_nav_links": e.extra_nav_links     | default({}),
   "show_powered_by": e.show_powered_by     | default(true),
   "sidebars": e.sidebars                   | default(["about", "toc", "related", "search"]),
+  "homepage_nav": e.homepage_nav           | default(true),
   "homepage_sidebars": e.homepage_sidebars | default(["about", "search"]),
 }%}

--- a/mkdocs_alabaster/main.html
+++ b/mkdocs_alabaster/main.html
@@ -44,7 +44,7 @@
         <div class="body" role="main">
           {% block content %}
             {{ page.content }}
-            {% if page.is_homepage %}
+            {% if page.is_homepage and theme.homepage_nav %}
               {% include "inc/homepage_nav.html" %}
             {% endif %}
           {% endblock %}


### PR DESCRIPTION
Add a theme configuration option that allows a user to not include the navigation tree on the home page. 