### PR TITLE
Automate new releases, pt. 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: python
 python:
   - 3.6
 
+if: tag IS present
+
 install:
   - curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
   - export PATH=$PATH:~/.poetry/bin
   - poetry install
 
 script:
-  # TODO: perhaps add some linting here
   - "true"
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ install:
   - export PATH=$PATH:~/.poetry/bin
   - poetry install
 
+script:
+  # TODO: perhaps add some linting here
+  - "true"
+
 deploy:
   provider: script
   script: poetry publish --build --username="$PYPI_USERNAME" --password="$PYPI_PASSWORD"


### PR DESCRIPTION
@moigagoo So, it fails on `master`: https://travis-ci.org/notpushkin/mkdocs-alabaster/jobs/548641301
My guess is that's because of an empty `script` section, as I don't see anything wrong in the log.
